### PR TITLE
add symbol and writepath for writing to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+fmt: 
+	deno fmt
 lint: 
 	deno lint --config deno.json
-test: 
+test: lint fmt
 	deno test --allow-write --allow-read
 test-watch: 
 	deno test --unstable --watch --allow-write --allow-read --no-check

--- a/write_read_test.ts
+++ b/write_read_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "./deps.ts";
-import { Format, stringify, write } from "./write.ts";
+import { Format, stdout, stringify, write } from "./write.ts";
 import { parse, read, readSync } from "./read.ts";
 
 const expected = {
@@ -137,4 +137,9 @@ Deno.test("read write multi yaml", async () => {
   await write(multiYaml, tmp, { format: Format.MULTI_YAML });
   const actual = await read(tmp);
   assertEquals(actual, multiYaml);
+});
+
+Deno.test("write json stdout", async () => {
+  // TODO(@adnaan): mock stdout for testing
+  await write(expected, stdout, { format: Format.YAML });
 });


### PR DESCRIPTION
Adds a `stdout` symbol to enable writing to stdout without a newline.